### PR TITLE
Fix Apache Install And Confgure Scripts

### DIFF
--- a/configure-eden-apache-mysql.sh
+++ b/configure-eden-apache-mysql.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Script to configure an Eden server
 # - assumes that install-eden-apache-mysql.sh has been run

--- a/install-eden-apache-mysql.sh
+++ b/install-eden-apache-mysql.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Script to turn a generic Debian Wheezy or Jessie box into an Eden server
 # with Apache & MySQL


### PR DESCRIPTION
Changed interpreter to /bin/bash from /bin/sh. Calling /bin/sh under Deb invokes dash, not bash.